### PR TITLE
Fix typos and improve ETHTornado tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Underlying circomlib dependency is currently being audited, and the team already
 
 ## Requirements
 
-1. `node v11.15.0`
+1. `node v12`
 2. `npm install -g npx`
 
 ## Usage

--- a/contracts/ETHTornado.sol
+++ b/contracts/ETHTornado.sol
@@ -23,7 +23,7 @@ contract ETHTornado is Tornado {
   ) Tornado(_verifier, _hasher, _denomination, _merkleTreeHeight) {}
 
   function _processDeposit() internal override {
-    require(msg.value == denomination, "Please send `mixDenomination` ETH along with transaction");
+    require(msg.value == denomination, "Please send `denomination` ETH along with transaction");
   }
 
   function _processWithdraw(
@@ -37,10 +37,10 @@ contract ETHTornado is Tornado {
     require(_refund == 0, "Refund value is supposed to be zero for ETH instance");
 
     (bool success, ) = _recipient.call{ value: denomination - _fee }("");
-    require(success, "payment to _recipient did not go thru");
+    require(success, "payment to _recipient did not go through");
     if (_fee > 0) {
       (success, ) = _relayer.call{ value: _fee }("");
-      require(success, "payment to _relayer did not go thru");
+      require(success, "payment to _relayer did not go through");
     }
   }
 }

--- a/test/ERC20Tornado.test.js
+++ b/test/ERC20Tornado.test.js
@@ -50,7 +50,7 @@ contract('ERC20Tornado', (accounts) => {
   let tokenDenomination = TOKEN_AMOUNT || '1000000000000000000' // 1 ether
   let snapshotId
   let tree
-  const fee = bigInt(ETH_AMOUNT).shr(1) || bigInt(1e17)
+  const fee = bigInt(ETH_AMOUNT ? ETH_AMOUNT : '1000000000000000000').shr(1)
   const refund = ETH_AMOUNT || '1000000000000000000' // 1 ether
   let recipient = getRandomRecipient()
   const relayer = accounts[1]

--- a/test/ETHTornado.test.js
+++ b/test/ETHTornado.test.js
@@ -60,7 +60,7 @@ contract('ETHTornado', (accounts) => {
   const value = ETH_AMOUNT || '1000000000000000000' // 1 ether
   let snapshotId
   let tree
-  const fee = bigInt(ETH_AMOUNT).shr(1) || bigInt(1e17)
+  const fee = bigInt(ETH_AMOUNT ? ETH_AMOUNT : '1000000000000000000').shr(1)
   const refund = bigInt(0)
   const recipient = getRandomRecipient()
   const relayer = accounts[1]
@@ -106,6 +106,13 @@ contract('ETHTornado', (accounts) => {
       await tornado.deposit(commitment, { value, from: sender }).should.be.fulfilled
       const error = await tornado.deposit(commitment, { value, from: sender }).should.be.rejected
       error.reason.should.be.equal('The commitment has been submitted')
+    })
+
+    it('should reject incorrect deposit amount', async () => {
+      const commitment = toFixedHex(77)
+      const wrongValue = toBN(value).add(toBN(1))
+      const error = await tornado.deposit(commitment, { value: wrongValue, from: sender }).should.be.rejected
+      error.reason.should.be.equal('Please send `denomination` ETH along with transaction')
     })
   })
 


### PR DESCRIPTION
## Summary
- correct Node version requirement
- fix spelling in ETHTornado revert strings
- protect test fee calculation if ETH_AMOUNT is unset
- add regression test for wrong ETH deposit amount

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684108b59e14832cb80638704f6a86b3